### PR TITLE
[Tabs] Fix podspec for resource bundle key

### DIFF
--- a/MaterialComponents.podspec
+++ b/MaterialComponents.podspec
@@ -312,20 +312,6 @@ Pod::Spec.new do |s|
     ss.dependency "MaterialComponents/private/RTL"
   end
 
-  s.subspec "Tabs" do |ss|
-    ss.ios.deployment_target = '7.0'
-    ss.public_header_files = "components/#{ss.base_name}/src/*.h"
-    ss.source_files = "components/#{ss.base_name}/src/*.{h,m}", "components/#{ss.base_name}/src/private/*.{h,m}"
-    ss.resource_bundles = {
-      "Material#{ss.base_name}" => ["components/#{ss.base_name}/src/Material#{ss.base_name}.bundle/*"]
-    }
-      
-    ss.dependency "MaterialComponents/AnimationTiming"
-    ss.dependency "MaterialComponents/Ink"
-    ss.dependency "MaterialComponents/Typography"
-    ss.dependency "MaterialComponents/private/RTL"
-  end
-
   s.subspec "Typography" do |ss|
     ss.ios.deployment_target = '7.0'
     ss.public_header_files = "components/#{ss.base_name}/src/*.h"


### PR DESCRIPTION
podspec was still using old (broken) way to link bundles.